### PR TITLE
fix: updated jQuery selector to work with jQuery v3.5

### DIFF
--- a/src/appserver/static/tabs.js
+++ b/src/appserver/static/tabs.js
@@ -31,7 +31,7 @@ require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/si
 			var targets = $(tabs[c]).data("elements").split(",");
 
 			for (var d = 0; d < targets.length; d++) {
-				$('#' + targets[d], this.$el).addClass('row-hide');
+				$(document.getElementById(targets[d]), this.$el).hide();
 			}
 		}
 	};
@@ -111,7 +111,7 @@ require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/si
 		for(var c = 0; c < toToggle.length; c++){
 			
 			// Show the items
-			$('#' + toToggle[c], this.$el).removeClass('row-hide');
+			$('#' + toToggle[c], this.$el).show();
 			
 			// Re-render the panels under the item if necessary
 			rerenderPanels(toToggle[c]);

--- a/src/appserver/static/tabs.js
+++ b/src/appserver/static/tabs.js
@@ -1,4 +1,4 @@
-require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/simplexml/ready!'],
+require(['jquery','underscore','splunkjs/mvc','splunkjs/mvc/simplexml/ready!'],
 		function($, _, mvc){
 	
 	var tabsInitialzed = [];
@@ -221,7 +221,7 @@ require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/si
 		});
 		
 		// Make the tabs into tabs
-		$('#tabs', this.$el).tab();
+		//$('#tabs', this.$el).tab();
 		
 		// Wire up the tab control tokenization
 		var submit = mvc.Components.get("submit");

--- a/src/appserver/static/tabs.js
+++ b/src/appserver/static/tabs.js
@@ -31,7 +31,7 @@ require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/si
 			var targets = $(tabs[c]).data("elements").split(",");
 
 			for (var d = 0; d < targets.length; d++) {
-				$(document.getElementById(targets[d]), this.$el).hide();
+				$(document.getElementById(targets[d]), this.$el).addClass('row-hide');
 			}
 		}
 	};
@@ -111,7 +111,7 @@ require(['jquery','underscore','splunkjs/mvc', 'bootstrap.tab', 'splunkjs/mvc/si
 		for(var c = 0; c < toToggle.length; c++){
 			
 			// Show the items
-			$('#' + toToggle[c], this.$el).show();
+			$(document.getElementById(toToggle[c]), this.$el).removeClass('row-hide');
 			
 			// Re-render the panels under the item if necessary
 			rerenderPanels(toToggle[c]);


### PR DESCRIPTION
Splunk is moving from jQuery v2.1 to v3.5 in new releases. 

The new jQuery v3.5 does not support $('#'), as it did in v2.1. The new regex characterEncoding is different in v3.5.

To fix this, the jQuery selector for targets[d] and toToggle[c] was updated to use a native .js DOM Element.

The tabs.js should now work in jQuery version 2.1 and 3.5 (Splunk xml version="1.0" and version="1.1")

edit: also updated the tabs.js to remove all references to bootstrap, as it is a deprecated feature in jQuery 3.5